### PR TITLE
Move minimum ESPHome version requirement into validator

### DIFF
--- a/components/evse_wallbox/__init__.py
+++ b/components/evse_wallbox/__init__.py
@@ -23,7 +23,8 @@ EVSE_WALLBOX_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 12, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(EvseWallbox),

--- a/components/evse_wallbox/__init__.py
+++ b/components/evse_wallbox/__init__.py
@@ -32,7 +32,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.polling_component_schema("5s"))
-    .extend(modbus.modbus_device_schema(0x01))
+    .extend(modbus.modbus_device_schema(0x01)),
 )
 
 

--- a/esp32-example-rev15.yaml
+++ b/esp32-example-rev15.yaml
@@ -9,7 +9,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-evse-wallbox"
     version: 1.3.0

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -9,7 +9,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-evse-wallbox"
     version: 1.3.0

--- a/esp8266-example-rev15.yaml
+++ b/esp8266-example-rev15.yaml
@@ -9,7 +9,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-evse-wallbox"
     version: 1.3.0

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -9,7 +9,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-evse-wallbox"
     version: 1.3.0

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -6,7 +6,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.6.0
 
 esp32:
   board: esp32-c6-devkitc-1

--- a/tests/esp8266-rcd-status-request.yaml
+++ b/tests/esp8266-rcd-status-request.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-evse-wallbox"
     version: 1.3.0

--- a/tests/esp8266-status-request.yaml
+++ b/tests/esp8266-status-request.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-evse-wallbox"
     version: 1.3.0


### PR DESCRIPTION
Removes min_version from all YAML configurations and enforces the version constraint via cv.require_esphome_version() in the component validator instead.