### PR TITLE
Replace deprecated DEVICE_CLASS_EMPTY and ICON_EMPTY with None

### DIFF
--- a/components/evse_wallbox/binary_sensor.py
+++ b/components/evse_wallbox/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC, ICON_EMPTY
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_EVSE_WALLBOX_ID, EVSE_WALLBOX_COMPONENT_SCHEMA
 
@@ -28,22 +28,22 @@ BINARY_SENSORS = [
 CONFIG_SCHEMA = EVSE_WALLBOX_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_RELAY): binary_sensor.binary_sensor_schema(
-            icon=ICON_EMPTY, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+            icon=None, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
         ),
         cv.Optional(CONF_DIODE_CHECK_FAILED): binary_sensor.binary_sensor_schema(
-            icon=ICON_EMPTY, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+            icon=None, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
         ),
         cv.Optional(CONF_VENTILATION_FAILED): binary_sensor.binary_sensor_schema(
-            icon=ICON_EMPTY, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+            icon=None, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
         ),
         cv.Optional(CONF_WAITING_FOR_PILOT_RELEASE): binary_sensor.binary_sensor_schema(
-            icon=ICON_EMPTY, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+            icon=None, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
         ),
         cv.Optional(CONF_RCD_TEST_IN_PROGRESS): binary_sensor.binary_sensor_schema(
-            icon=ICON_EMPTY, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+            icon=None, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
         ),
         cv.Optional(CONF_RCD_CHECK_ERROR): binary_sensor.binary_sensor_schema(
-            icon=ICON_EMPTY, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+            icon=None, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
         ),
     }
 )

--- a/components/evse_wallbox/button/__init__.py
+++ b/components/evse_wallbox/button/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import button
 import esphome.config_validation as cv
-from esphome.const import ICON_EMPTY
+
 
 from .. import CONF_EVSE_WALLBOX_ID, EVSE_WALLBOX_COMPONENT_SCHEMA, evse_wallbox_ns
 
@@ -24,13 +24,13 @@ EvseButton = evse_wallbox_ns.class_("EvseButton", button.Button, cg.Component)
 CONFIG_SCHEMA = EVSE_WALLBOX_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_TURN_OFF_CHARGING): button.button_schema(
-            EvseButton, icon=ICON_EMPTY
+            EvseButton, icon=None
         ),
         cv.Optional(CONF_START_SELF_TEST): button.button_schema(
-            EvseButton, icon=ICON_EMPTY
+            EvseButton, icon=None
         ),
         cv.Optional(CONF_CLEAR_RCD_ERROR): button.button_schema(
-            EvseButton, icon=ICON_EMPTY
+            EvseButton, icon=None
         ),
     }
 )

--- a/components/evse_wallbox/button/__init__.py
+++ b/components/evse_wallbox/button/__init__.py
@@ -2,7 +2,6 @@ import esphome.codegen as cg
 from esphome.components import button
 import esphome.config_validation as cv
 
-
 from .. import CONF_EVSE_WALLBOX_ID, EVSE_WALLBOX_COMPONENT_SCHEMA, evse_wallbox_ns
 
 DEPENDENCIES = ["evse_wallbox"]
@@ -26,12 +25,8 @@ CONFIG_SCHEMA = EVSE_WALLBOX_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_TURN_OFF_CHARGING): button.button_schema(
             EvseButton, icon=None
         ),
-        cv.Optional(CONF_START_SELF_TEST): button.button_schema(
-            EvseButton, icon=None
-        ),
-        cv.Optional(CONF_CLEAR_RCD_ERROR): button.button_schema(
-            EvseButton, icon=None
-        ),
+        cv.Optional(CONF_START_SELF_TEST): button.button_schema(EvseButton, icon=None),
+        cv.Optional(CONF_CLEAR_RCD_ERROR): button.button_schema(EvseButton, icon=None),
     }
 )
 

--- a/components/evse_wallbox/number/__init__.py
+++ b/components/evse_wallbox/number/__init__.py
@@ -8,7 +8,6 @@ from esphome.const import (
     CONF_MODE,
     CONF_STEP,
     ENTITY_CATEGORY_CONFIG,
-    ICON_EMPTY,
     UNIT_AMPERE,
 )
 
@@ -35,7 +34,7 @@ EvseNumber = evse_wallbox_ns.class_("EvseNumber", number.Number, cg.Component)
 EVSE_NUMBER_SCHEMA = (
     number.number_schema(
         EvseNumber,
-        icon=ICON_EMPTY,
+        icon=None,
         entity_category=ENTITY_CATEGORY_CONFIG,
         unit_of_measurement=UNIT_AMPERE,
     )

--- a/components/evse_wallbox/sensor.py
+++ b/components/evse_wallbox/sensor.py
@@ -3,8 +3,6 @@ from esphome.components import sensor
 import esphome.config_validation as cv
 from esphome.const import (
     DEVICE_CLASS_CURRENT,
-    DEVICE_CLASS_EMPTY,
-    ICON_EMPTY,
     STATE_CLASS_MEASUREMENT,
     UNIT_AMPERE,
     UNIT_EMPTY,
@@ -47,7 +45,7 @@ CONFIG_SCHEMA = EVSE_WALLBOX_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_OUTPUT_CURRENT_SETTING): sensor.sensor_schema(
             unit_of_measurement=UNIT_AMPERE,
-            icon=ICON_EMPTY,
+            icon=None,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_CURRENT,
             state_class=STATE_CLASS_MEASUREMENT,
@@ -63,7 +61,7 @@ CONFIG_SCHEMA = EVSE_WALLBOX_COMPONENT_SCHEMA.extend(
             unit_of_measurement=UNIT_EMPTY,
             icon="mdi:car-electric",
             accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
+            device_class=None,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_CABLE_LIMIT_DETECTED): sensor.sensor_schema(
@@ -77,49 +75,49 @@ CONFIG_SCHEMA = EVSE_WALLBOX_COMPONENT_SCHEMA.extend(
             unit_of_measurement=UNIT_EMPTY,
             icon="mdi:remote",
             accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
+            device_class=None,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_FIRMWARE_VERSION): sensor.sensor_schema(
             unit_of_measurement=UNIT_EMPTY,
             icon="mdi:numeric",
             accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
+            device_class=None,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_OPERATION_MODE_CODE): sensor.sensor_schema(
             unit_of_measurement=UNIT_EMPTY,
             icon="mdi:pulse",
             accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
+            device_class=None,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_ERROR_BITMASK): sensor.sensor_schema(
             unit_of_measurement=UNIT_EMPTY,
             icon="mdi:alert-circle",
             accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
+            device_class=None,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_ERROR_TIMEOUT_COUNTDOWN): sensor.sensor_schema(
             unit_of_measurement=UNIT_EMPTY,
             icon="mdi:timer-remove-outline",
             accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
+            device_class=None,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_SELF_TEST_TIMEOUT_COUNTDOWN): sensor.sensor_schema(
             unit_of_measurement=UNIT_EMPTY,
             icon="mdi:timer-remove-outline",
             accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
+            device_class=None,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_CONFIG_BITS): sensor.sensor_schema(
             unit_of_measurement=UNIT_EMPTY,
             icon="mdi:cog",
             accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
+            device_class=None,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
     }

--- a/components/evse_wallbox/switch/__init__.py
+++ b/components/evse_wallbox/switch/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
-from esphome.const import ENTITY_CATEGORY_CONFIG, ICON_EMPTY
+from esphome.const import ENTITY_CATEGORY_CONFIG
 
 from .. import CONF_EVSE_WALLBOX_ID, EVSE_WALLBOX_COMPONENT_SCHEMA, evse_wallbox_ns
 
@@ -39,52 +39,52 @@ CONFIG_SCHEMA = EVSE_WALLBOX_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_CURRENT_CHANGE_BY_BUTTON): switch.switch_schema(
             EvseSwitch,
-            icon=ICON_EMPTY,
+            icon=None,
             entity_category=ENTITY_CATEGORY_CONFIG,
         ),
         cv.Optional(CONF_STOP_CHARGING_ON_BUTTON_PRESS): switch.switch_schema(
             EvseSwitch,
-            icon=ICON_EMPTY,
+            icon=None,
             entity_category=ENTITY_CATEGORY_CONFIG,
         ),
         cv.Optional(CONF_PILOT_READY_STATE_LED_ALWAYS_ON): switch.switch_schema(
             EvseSwitch,
-            icon=ICON_EMPTY,
+            icon=None,
             entity_category=ENTITY_CATEGORY_CONFIG,
         ),
         cv.Optional(CONF_CHARGING_OF_VEHICLE_STATUS_D): switch.switch_schema(
             EvseSwitch,
-            icon=ICON_EMPTY,
+            icon=None,
             entity_category=ENTITY_CATEGORY_CONFIG,
         ),
         cv.Optional(CONF_RCD_FEEDBACK_ON_MCLR_PIN): switch.switch_schema(
             EvseSwitch,
-            icon=ICON_EMPTY,
+            icon=None,
             entity_category=ENTITY_CATEGORY_CONFIG,
         ),
         cv.Optional(CONF_AUTO_CLEAR_RCD_ERROR): switch.switch_schema(
             EvseSwitch,
-            icon=ICON_EMPTY,
+            icon=None,
             entity_category=ENTITY_CATEGORY_CONFIG,
         ),
         cv.Optional(CONF_AN_INTERNAL_PULLUP): switch.switch_schema(
             EvseSwitch,
-            icon=ICON_EMPTY,
+            icon=None,
             entity_category=ENTITY_CATEGORY_CONFIG,
         ),
         cv.Optional(CONF_DISABLE_EVSE_AFTER_CHARGE): switch.switch_schema(
             EvseSwitch,
-            icon=ICON_EMPTY,
+            icon=None,
             entity_category=ENTITY_CATEGORY_CONFIG,
         ),
         cv.Optional(CONF_DISABLE_EVSE): switch.switch_schema(
             EvseSwitch,
-            icon=ICON_EMPTY,
+            icon=None,
             entity_category=ENTITY_CATEGORY_CONFIG,
         ),
         cv.Optional(CONF_BOOTLOADER_MODE): switch.switch_schema(
             EvseSwitch,
-            icon=ICON_EMPTY,
+            icon=None,
             entity_category=ENTITY_CATEGORY_CONFIG,
         ),
     }


### PR DESCRIPTION
Replace deprecated `DEVICE_CLASS_EMPTY` and `ICON_EMPTY` constants with `None` and remove them from the `esphome.const` import list.

These constants are deprecated and empty/`None` is the correct replacement per the ESPHome cleanup plan.