### PR TITLE
Fix bitmask sensor

### DIFF
--- a/components/evse_wallbox/sensor.py
+++ b/components/evse_wallbox/sensor.py
@@ -78,7 +78,7 @@ CONFIG_SCHEMA = EVSE_WALLBOX_COMPONENT_SCHEMA.extend(
             unit_of_measurement=UNIT_EMPTY,
             icon="mdi:remote",
             accuracy_decimals=0,
-            device_class=None,
+            device_class=DEVICE_CLASS_EMPTY,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_FIRMWARE_VERSION): sensor.sensor_schema(
@@ -99,7 +99,7 @@ CONFIG_SCHEMA = EVSE_WALLBOX_COMPONENT_SCHEMA.extend(
             unit_of_measurement=UNIT_EMPTY,
             icon="mdi:alert-circle",
             accuracy_decimals=0,
-            device_class=None,
+            device_class=DEVICE_CLASS_EMPTY,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_ERROR_TIMEOUT_COUNTDOWN): sensor.sensor_schema(


### PR DESCRIPTION
`device_class=None` is not a valid value in ESPHome's sensor schema and causes a validation error:

```
string value is None.
Error: Process completed with exit code 2.
```

Replace with `DEVICE_CLASS_EMPTY` which is the correct constant for sensors without a device class.