### PR TITLE
Remove redundant name substitution prefix from entity names

### DIFF
--- a/esp32-example-rev15.yaml
+++ b/esp32-example-rev15.yaml
@@ -8,6 +8,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-evse-wallbox"

--- a/esp32-example-rev15.yaml
+++ b/esp32-example-rev15.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: evse-wallbox
-  config_name: "${name} config"
+  config_name: "config"
   device_description: "Monitor and control a EVSE wallbox via RS485 (Modbus)"
   external_components_source: github://syssi/esphome-evse-wallbox@main
   tx_pin: GPIO16
@@ -64,37 +64,37 @@ evse_wallbox:
 button:
   - platform: evse_wallbox
     turn_off_charging:
-      name: "${name} turn off charging"
+      name: "turn off charging"
     start_self_test:
-      name: "${name} start self-test"
+      name: "start self-test"
     clear_rcd_error:
-      name: "${name} clear rcd error"
+      name: "clear rcd error"
 
 number:
   - platform: evse_wallbox
     output_current_setting:
-      name: "${name} output current setting"
+      name: "output current setting"
     output_current_default:
-      name: "${name} output current default"
+      name: "output current default"
     min_charging_current:
-      name: "${name} minimum charging current"
+      name: "minimum charging current"
 
 sensor:
   - platform: evse_wallbox
     output_current_setting:
-      name: "${name} output current setting"
+      name: "output current setting"
     output_current:
-      name: "${name} output current"
+      name: "output current"
     vehicle_status_code:
-      name: "${name} vehicle status code"
+      name: "vehicle status code"
     cable_limit_detected:
-      name: "${name} cable limit detected"
+      name: "cable limit detected"
     last_command_bitmask:
-      name: "${name} last command bitmask"
+      name: "last command bitmask"
     firmware_version:
-      name: "${name} firmware version"
+      name: "firmware version"
     operation_mode_code:
-      name: "${name} operation mode code"
+      name: "operation mode code"
     config_bits:
       name: "${config_name} config bits"
 
@@ -124,8 +124,8 @@ switch:
 text_sensor:
   - platform: evse_wallbox
     vehicle_status:
-      name: "${name} vehicle status"
+      name: "vehicle status"
     last_command:
-      name: "${name} last command"
+      name: "last command"
     operation_mode:
-      name: "${name} operation mode"
+      name: "operation mode"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -8,6 +8,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-evse-wallbox"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: evse-wallbox
-  config_name: "${name} config"
+  config_name: "config"
   device_description: "Monitor and control a EVSE wallbox via RS485 (Modbus)"
   external_components_source: github://syssi/esphome-evse-wallbox@main
   tx_pin: GPIO16
@@ -64,58 +64,58 @@ evse_wallbox:
 binary_sensor:
   - platform: evse_wallbox
     relay:
-      name: "${name} relay"
+      name: "relay"
     diode_check_failed:
-      name: "${name} diode check failed"
+      name: "diode check failed"
     ventilation_failed:
-      name: "${name} ventilation failed"
+      name: "ventilation failed"
     waiting_for_pilot_release:
-      name: "${name} waiting for pilot release"
+      name: "waiting for pilot release"
     rcd_test_in_progress:
-      name: "${name} rcd test in progress"
+      name: "rcd test in progress"
     rcd_check_error:
-      name: "${name} rcd check error"
+      name: "rcd check error"
 
 button:
   - platform: evse_wallbox
     turn_off_charging:
-      name: "${name} turn off charging"
+      name: "turn off charging"
     start_self_test:
-      name: "${name} start self-test"
+      name: "start self-test"
     clear_rcd_error:
-      name: "${name} clear rcd error"
+      name: "clear rcd error"
 
 number:
   - platform: evse_wallbox
     output_current_setting:
-      name: "${name} output current setting"
+      name: "output current setting"
     output_current_default:
-      name: "${name} output current default"
+      name: "output current default"
     min_charging_current:
-      name: "${name} minimum charging current"
+      name: "minimum charging current"
 
 sensor:
   - platform: evse_wallbox
     output_current_setting:
-      name: "${name} output current setting"
+      name: "output current setting"
     output_current:
-      name: "${name} output current"
+      name: "output current"
     vehicle_status_code:
-      name: "${name} vehicle status code"
+      name: "vehicle status code"
     cable_limit_detected:
-      name: "${name} cable limit detected"
+      name: "cable limit detected"
     last_command_bitmask:
-      name: "${name} last command bitmask"
+      name: "last command bitmask"
     firmware_version:
-      name: "${name} firmware version"
+      name: "firmware version"
     operation_mode_code:
-      name: "${name} operation mode code"
+      name: "operation mode code"
     error_bitmask:
-      name: "${name} error bitmask"
+      name: "error bitmask"
     error_timeout_countdown:
-      name: "${name} error timeout countdown"
+      name: "error timeout countdown"
     self_test_timeout_countdown:
-      name: "${name} self-test timeout countdown"
+      name: "self-test timeout countdown"
     config_bits:
       name: "${config_name} config bits"
 
@@ -145,10 +145,10 @@ switch:
 text_sensor:
   - platform: evse_wallbox
     vehicle_status:
-      name: "${name} vehicle status"
+      name: "vehicle status"
     last_command:
-      name: "${name} last command"
+      name: "last command"
     operation_mode:
-      name: "${name} operation mode"
+      name: "operation mode"
     errors:
-      name: "${name} errors"
+      name: "errors"

--- a/esp8266-example-rev15.yaml
+++ b/esp8266-example-rev15.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: evse-wallbox
-  config_name: "${name} config"
+  config_name: "config"
   device_description: "Monitor and control a EVSE wallbox via RS485 (Modbus)"
   external_components_source: github://syssi/esphome-evse-wallbox@main
   tx_pin: GPIO4
@@ -62,37 +62,37 @@ evse_wallbox:
 button:
   - platform: evse_wallbox
     turn_off_charging:
-      name: "${name} turn off charging"
+      name: "turn off charging"
     start_self_test:
-      name: "${name} start self-test"
+      name: "start self-test"
     clear_rcd_error:
-      name: "${name} clear rcd error"
+      name: "clear rcd error"
 
 number:
   - platform: evse_wallbox
     output_current_setting:
-      name: "${name} output current setting"
+      name: "output current setting"
     output_current_default:
-      name: "${name} output current default"
+      name: "output current default"
     min_charging_current:
-      name: "${name} minimum charging current"
+      name: "minimum charging current"
 
 sensor:
   - platform: evse_wallbox
     output_current_setting:
-      name: "${name} output current setting"
+      name: "output current setting"
     output_current:
-      name: "${name} output current"
+      name: "output current"
     vehicle_status_code:
-      name: "${name} vehicle status code"
+      name: "vehicle status code"
     cable_limit_detected:
-      name: "${name} cable limit detected"
+      name: "cable limit detected"
     last_command_bitmask:
-      name: "${name} last command bitmask"
+      name: "last command bitmask"
     firmware_version:
-      name: "${name} firmware version"
+      name: "firmware version"
     operation_mode_code:
-      name: "${name} operation mode code"
+      name: "operation mode code"
     config_bits:
       name: "${config_name} config bits"
 
@@ -122,8 +122,8 @@ switch:
 text_sensor:
   - platform: evse_wallbox
     vehicle_status:
-      name: "${name} vehicle status"
+      name: "vehicle status"
     last_command:
-      name: "${name} last command"
+      name: "last command"
     operation_mode:
-      name: "${name} operation mode"
+      name: "operation mode"

--- a/esp8266-example-rev15.yaml
+++ b/esp8266-example-rev15.yaml
@@ -8,6 +8,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-evse-wallbox"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -8,6 +8,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-evse-wallbox"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: evse-wallbox
-  config_name: "${name} config"
+  config_name: "config"
   device_description: "Monitor and control a EVSE wallbox via RS485 (Modbus)"
   external_components_source: github://syssi/esphome-evse-wallbox@main
   tx_pin: GPIO4
@@ -62,58 +62,58 @@ evse_wallbox:
 binary_sensor:
   - platform: evse_wallbox
     relay:
-      name: "${name} relay"
+      name: "relay"
     diode_check_failed:
-      name: "${name} diode check failed"
+      name: "diode check failed"
     ventilation_failed:
-      name: "${name} ventilation failed"
+      name: "ventilation failed"
     waiting_for_pilot_release:
-      name: "${name} waiting for pilot release"
+      name: "waiting for pilot release"
     rcd_test_in_progress:
-      name: "${name} rcd test in progress"
+      name: "rcd test in progress"
     rcd_check_error:
-      name: "${name} rcd check error"
+      name: "rcd check error"
 
 button:
   - platform: evse_wallbox
     turn_off_charging:
-      name: "${name} turn off charging"
+      name: "turn off charging"
     start_self_test:
-      name: "${name} start self-test"
+      name: "start self-test"
     clear_rcd_error:
-      name: "${name} clear rcd error"
+      name: "clear rcd error"
 
 number:
   - platform: evse_wallbox
     output_current_setting:
-      name: "${name} output current setting"
+      name: "output current setting"
     output_current_default:
-      name: "${name} output current default"
+      name: "output current default"
     min_charging_current:
-      name: "${name} minimum charging current"
+      name: "minimum charging current"
 
 sensor:
   - platform: evse_wallbox
     output_current_setting:
-      name: "${name} output current setting"
+      name: "output current setting"
     output_current:
-      name: "${name} output current"
+      name: "output current"
     vehicle_status_code:
-      name: "${name} vehicle status code"
+      name: "vehicle status code"
     cable_limit_detected:
-      name: "${name} cable limit detected"
+      name: "cable limit detected"
     last_command_bitmask:
-      name: "${name} last command bitmask"
+      name: "last command bitmask"
     firmware_version:
-      name: "${name} firmware version"
+      name: "firmware version"
     operation_mode_code:
-      name: "${name} operation mode code"
+      name: "operation mode code"
     error_bitmask:
-      name: "${name} error bitmask"
+      name: "error bitmask"
     error_timeout_countdown:
-      name: "${name} error timeout countdown"
+      name: "error timeout countdown"
     self_test_timeout_countdown:
-      name: "${name} self-test timeout countdown"
+      name: "self-test timeout countdown"
     config_bits:
       name: "${config_name} config bits"
 
@@ -143,10 +143,10 @@ switch:
 text_sensor:
   - platform: evse_wallbox
     vehicle_status:
-      name: "${name} vehicle status"
+      name: "vehicle status"
     last_command:
-      name: "${name} last command"
+      name: "last command"
     operation_mode:
-      name: "${name} operation mode"
+      name: "operation mode"
     errors:
-      name: "${name} errors"
+      name: "errors"

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
 
 esp32:

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -50,4 +50,4 @@ evse_wallbox:
 sensor:
   - platform: evse_wallbox
     output_current_setting:
-      name: "${name} output current setting"
+      name: "output current setting"

--- a/tests/esp8266-rcd-status-request.yaml
+++ b/tests/esp8266-rcd-status-request.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-evse-wallbox"

--- a/tests/esp8266-status-request.yaml
+++ b/tests/esp8266-status-request.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-evse-wallbox"


### PR DESCRIPTION
ESPHome's `friendly_name` automatically prefixes all entity names, making the `${name}` substitution in entity name strings redundant.