### PR TITLE
Refactor sensor and binary_sensor schema definitions

### DIFF
--- a/components/evse_wallbox/binary_sensor.py
+++ b/components/evse_wallbox/binary_sensor.py
@@ -16,42 +16,41 @@ CONF_WAITING_FOR_PILOT_RELEASE = "waiting_for_pilot_release"
 CONF_RCD_TEST_IN_PROGRESS = "rcd_test_in_progress"
 CONF_RCD_CHECK_ERROR = "rcd_check_error"
 
-BINARY_SENSORS = [
-    CONF_RELAY,
-    CONF_DIODE_CHECK_FAILED,
-    CONF_VENTILATION_FAILED,
-    CONF_WAITING_FOR_PILOT_RELEASE,
-    CONF_RCD_TEST_IN_PROGRESS,
-    CONF_RCD_CHECK_ERROR,
-]
+BINARY_SENSOR_DEFS = {
+    CONF_RELAY: {"icon": ICON_EMPTY, "entity_category": ENTITY_CATEGORY_DIAGNOSTIC},
+    CONF_DIODE_CHECK_FAILED: {
+        "icon": ICON_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_VENTILATION_FAILED: {
+        "icon": ICON_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_WAITING_FOR_PILOT_RELEASE: {
+        "icon": ICON_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_RCD_TEST_IN_PROGRESS: {
+        "icon": ICON_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_RCD_CHECK_ERROR: {
+        "icon": ICON_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+}
 
 CONFIG_SCHEMA = EVSE_WALLBOX_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_RELAY): binary_sensor.binary_sensor_schema(
-            icon=ICON_EMPTY, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
-        ),
-        cv.Optional(CONF_DIODE_CHECK_FAILED): binary_sensor.binary_sensor_schema(
-            icon=ICON_EMPTY, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
-        ),
-        cv.Optional(CONF_VENTILATION_FAILED): binary_sensor.binary_sensor_schema(
-            icon=ICON_EMPTY, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
-        ),
-        cv.Optional(CONF_WAITING_FOR_PILOT_RELEASE): binary_sensor.binary_sensor_schema(
-            icon=ICON_EMPTY, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
-        ),
-        cv.Optional(CONF_RCD_TEST_IN_PROGRESS): binary_sensor.binary_sensor_schema(
-            icon=ICON_EMPTY, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
-        ),
-        cv.Optional(CONF_RCD_CHECK_ERROR): binary_sensor.binary_sensor_schema(
-            icon=ICON_EMPTY, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
-        ),
+        cv.Optional(key): binary_sensor.binary_sensor_schema(**kwargs)
+        for key, kwargs in BINARY_SENSOR_DEFS.items()
     }
 )
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_EVSE_WALLBOX_ID])
-    for key in BINARY_SENSORS:
+    for key in BINARY_SENSOR_DEFS:
         if key in config:
             conf = config[key]
             sens = await binary_sensor.new_binary_sensor(conf)

--- a/components/evse_wallbox/sensor.py
+++ b/components/evse_wallbox/sensor.py
@@ -29,107 +29,97 @@ CONF_ERROR_TIMEOUT_COUNTDOWN = "error_timeout_countdown"
 CONF_SELF_TEST_TIMEOUT_COUNTDOWN = "self_test_timeout_countdown"
 CONF_CONFIG_BITS = "config_bits"
 
-SENSORS = [
-    CONF_OUTPUT_CURRENT_SETTING,
-    CONF_OUTPUT_CURRENT,
-    CONF_VEHICLE_STATUS_CODE,
-    CONF_CABLE_LIMIT_DETECTED,
-    CONF_LAST_COMMAND_BITMASK,
-    CONF_FIRMWARE_VERSION,
-    CONF_OPERATION_MODE_CODE,
-    CONF_ERROR_BITMASK,
-    CONF_ERROR_TIMEOUT_COUNTDOWN,
-    CONF_SELF_TEST_TIMEOUT_COUNTDOWN,
-    CONF_CONFIG_BITS,
-]
+SENSOR_DEFS = {
+    CONF_OUTPUT_CURRENT_SETTING: {
+        "unit_of_measurement": UNIT_AMPERE,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_CURRENT,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_OUTPUT_CURRENT: {
+        "unit_of_measurement": UNIT_AMPERE,
+        "icon": "mdi:ev-plug-type2",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_CURRENT,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_VEHICLE_STATUS_CODE: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:car-electric",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CABLE_LIMIT_DETECTED: {
+        "unit_of_measurement": UNIT_AMPERE,
+        "icon": "mdi:cable-data",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_CURRENT,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_LAST_COMMAND_BITMASK: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:remote",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_FIRMWARE_VERSION: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:numeric",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_OPERATION_MODE_CODE: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:pulse",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_ERROR_BITMASK: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:alert-circle",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_ERROR_TIMEOUT_COUNTDOWN: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:timer-remove-outline",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_SELF_TEST_TIMEOUT_COUNTDOWN: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:timer-remove-outline",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CONFIG_BITS: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:cog",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+}
 
-# pylint: disable=too-many-function-args
 CONFIG_SCHEMA = EVSE_WALLBOX_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_OUTPUT_CURRENT_SETTING): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE,
-            icon=ICON_EMPTY,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_CURRENT,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_OUTPUT_CURRENT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE,
-            icon="mdi:ev-plug-type2",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_CURRENT,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_VEHICLE_STATUS_CODE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:car-electric",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CABLE_LIMIT_DETECTED): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE,
-            icon="mdi:cable-data",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_CURRENT,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_LAST_COMMAND_BITMASK): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:remote",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_FIRMWARE_VERSION): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:numeric",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_OPERATION_MODE_CODE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:pulse",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_ERROR_BITMASK): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:alert-circle",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_ERROR_TIMEOUT_COUNTDOWN): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:timer-remove-outline",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_SELF_TEST_TIMEOUT_COUNTDOWN): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:timer-remove-outline",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CONFIG_BITS): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:cog",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
+        cv.Optional(key): sensor.sensor_schema(**kwargs)
+        for key, kwargs in SENSOR_DEFS.items()
     }
 )
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_EVSE_WALLBOX_ID])
-    for key in SENSORS:
+    for key in SENSOR_DEFS:
         if key in config:
             conf = config[key]
             sens = await sensor.new_sensor(conf)


### PR DESCRIPTION
Replace flat SENSORS/BINARY_SENSORS lists and manual CONFIG_SCHEMA entries with SENSOR_DEFS/BINARY_SENSOR_DEFS dicts. Reduces repetition and makes adding new entities easier.

Reference: syssi/esphome-daly-bms#85