### PR TITLE
Replace static const char arrays with constexpr

### DIFF
--- a/components/evse_wallbox/evse_wallbox.cpp
+++ b/components/evse_wallbox/evse_wallbox.cpp
@@ -18,7 +18,7 @@ static const uint16_t REGISTERS_CONFIG_START = 2000;
 static const uint16_t REGISTERS_CONFIG_COUNT = 18;
 
 static const uint8_t VEHICLE_STATES_SIZE = 6;
-static const char *const VEHICLE_STATES[VEHICLE_STATES_SIZE] = {
+static constexpr const char *const VEHICLE_STATES[VEHICLE_STATES_SIZE] = {
     "",                           // 0x00
     "Ready",                      // 0x01
     "Present",                    // 0x02
@@ -28,7 +28,7 @@ static const char *const VEHICLE_STATES[VEHICLE_STATES_SIZE] = {
 };
 
 static const uint8_t OPERATION_MODES_SIZE = 4;
-static const char *const OPERATION_MODES[OPERATION_MODES_SIZE] = {
+static constexpr const char *const OPERATION_MODES[OPERATION_MODES_SIZE] = {
     "",         // 0x00
     "12V",      // 0x01
     "PWM",      // 0x02
@@ -36,7 +36,7 @@ static const char *const OPERATION_MODES[OPERATION_MODES_SIZE] = {
 };
 
 static const uint8_t ERRORS_SIZE = 6;
-static const char *const ERRORS[ERRORS_SIZE] = {
+static constexpr const char *const ERRORS[ERRORS_SIZE] = {
     "Relay on",                                          // 1
     "Diode check failed",                                // 2
     "Ventilation failed",                                // 4


### PR DESCRIPTION
## Summary

- Replaces `static const char *const` with `static constexpr const char *const` for the three string arrays `VEHICLE_STATES`, `OPERATION_MODES`, and `ERRORS` in `components/evse_wallbox/evse_wallbox.cpp` (lines 21, 31, 39).

## Why

Using `static constexpr const char *const` for string literal arrays ensures the data is placed in the read-only segment (Flash) at compile time rather than consuming precious RAM at runtime. This matches the style used in the ESPHome core (e.g. `bme68x_bsec2.cpp`) and is the idiomatic approach for constant string tables on embedded targets.

## Test plan

- [x] Verify the component compiles without warnings or errors
- [x] Confirm runtime behaviour is unchanged (vehicle state, operation mode and error text sensors still report correct strings)