### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/evse_wallbox/button/evse_button.cpp
+++ b/components/evse_wallbox/button/evse_button.cpp
@@ -2,13 +2,11 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace evse_wallbox {
+namespace esphome::evse_wallbox {
 
 static const char *const TAG = "evse_wallbox.button";
 
 void EvseButton::dump_config() { LOG_BUTTON("", "EvseWallbox Button", this); }
 void EvseButton::press_action() { this->parent_->write_register(this->holding_register_, this->payload_); }
 
-}  // namespace evse_wallbox
-}  // namespace esphome
+}  // namespace esphome::evse_wallbox

--- a/components/evse_wallbox/button/evse_button.h
+++ b/components/evse_wallbox/button/evse_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace evse_wallbox {
+namespace esphome::evse_wallbox {
 
 class EvseWallbox;
 
@@ -25,5 +24,4 @@ class EvseButton : public button::Button, public Component {
   uint16_t payload_;
 };
 
-}  // namespace evse_wallbox
-}  // namespace esphome
+}  // namespace esphome::evse_wallbox

--- a/components/evse_wallbox/evse_wallbox.cpp
+++ b/components/evse_wallbox/evse_wallbox.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace evse_wallbox {
+namespace esphome::evse_wallbox {
 
 static const char *const TAG = "evse_wallbox";
 
@@ -334,5 +333,4 @@ std::string EvseWallbox::error_bits_to_string_(const uint16_t mask) {
   return errors_list;
 }
 
-}  // namespace evse_wallbox
-}  // namespace esphome
+}  // namespace esphome::evse_wallbox

--- a/components/evse_wallbox/evse_wallbox.h
+++ b/components/evse_wallbox/evse_wallbox.h
@@ -8,8 +8,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/modbus/modbus.h"
 
-namespace esphome {
-namespace evse_wallbox {
+namespace esphome::evse_wallbox {
 
 class EvseWallbox : public PollingComponent, public modbus::ModbusDevice {
  public:
@@ -182,5 +181,4 @@ class EvseWallbox : public PollingComponent, public modbus::ModbusDevice {
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);
 };
 
-}  // namespace evse_wallbox
-}  // namespace esphome
+}  // namespace esphome::evse_wallbox

--- a/components/evse_wallbox/number/evse_number.cpp
+++ b/components/evse_wallbox/number/evse_number.cpp
@@ -1,8 +1,7 @@
 #include "evse_number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace evse_wallbox {
+namespace esphome::evse_wallbox {
 
 static const char *const TAG = "evse_wallbox.number";
 
@@ -11,5 +10,4 @@ void EvseNumber::control(float value) {
   this->parent_->write_register(this->holding_register_, (uint16_t) (value * (1.0f / this->traits.get_step())));
 }
 
-}  // namespace evse_wallbox
-}  // namespace esphome
+}  // namespace esphome::evse_wallbox

--- a/components/evse_wallbox/number/evse_number.h
+++ b/components/evse_wallbox/number/evse_number.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/number/number.h"
 
-namespace esphome {
-namespace evse_wallbox {
+namespace esphome::evse_wallbox {
 
 class EvseWallbox;
 
@@ -22,5 +21,4 @@ class EvseNumber : public number::Number, public Component {
   uint16_t holding_register_;
 };
 
-}  // namespace evse_wallbox
-}  // namespace esphome
+}  // namespace esphome::evse_wallbox

--- a/components/evse_wallbox/switch/evse_switch.cpp
+++ b/components/evse_wallbox/switch/evse_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace evse_wallbox {
+namespace esphome::evse_wallbox {
 
 static const char *const TAG = "evse_wallbox.switch";
 
@@ -17,5 +16,4 @@ void EvseSwitch::write_state(bool state) {
   ESP_LOGE(TAG, "The holding register (%d) isn't supported by the switch entity yet.", this->holding_register_);
 }
 
-}  // namespace evse_wallbox
-}  // namespace esphome
+}  // namespace esphome::evse_wallbox

--- a/components/evse_wallbox/switch/evse_switch.h
+++ b/components/evse_wallbox/switch/evse_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace evse_wallbox {
+namespace esphome::evse_wallbox {
 
 class EvseWallbox;
 
@@ -25,5 +24,4 @@ class EvseSwitch : public switch_::Switch, public Component {
   uint16_t bit_field_;
 };
 
-}  // namespace evse_wallbox
-}  // namespace esphome
+}  // namespace esphome::evse_wallbox


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.